### PR TITLE
[1.2] Add MP.Utility

### DIFF
--- a/src/AlternateLife.RageMP.Net/Interfaces/IUtility.cs
+++ b/src/AlternateLife.RageMP.Net/Interfaces/IUtility.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AlternateLife.RageMP.Net.Interfaces
+{
+    public interface IUtility
+    {
+        /// <summary>
+        /// Converts given string to the equivalent Jenkins-One-At-A-Time value.
+        ///
+        /// https://en.wikipedia.org/wiki/Jenkins_hash_function#one_at_a_time
+        /// </summary>
+        /// <param name="data">text to convert</param>
+        /// <returns>Integer that represents given string data</returns>
+        uint Joaat(string data);
+
+        /// <summary>
+        /// Converts given collection of strings to Jenkins-One-At-A-Time values.
+        ///
+        /// https://en.wikipedia.org/wiki/Jenkins_hash_function#one_at_a_time
+        /// </summary>
+        /// <param name="input">texts to convert</param>
+        /// <returns>Collection of converted values</returns>
+        IList<uint> Joaat(IList<string> input);
+
+        /// <summary>
+        /// Schedules given <see cref="Action"/> in RageMP's main thread.
+        ///
+        /// WARNING: Avoid long procedures, because this could harm general event performance.
+        /// </summary>
+        /// <param name="action"><paramref name="action"/> to schedule</param>
+        /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
+        Task Schedule(Action action, bool forceSchedule = false);
+
+        /// <summary>
+        /// Schedules given <see cref="Func{TResult}"/> in RageMP's main thread.
+        ///
+        /// WARNING: Avoid long procedures, because this could harm general event performance.
+        /// </summary>
+        /// <param name="action"><paramref name="action"/> to schedule</param>
+        /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
+        Task<T> Schedule<T>(Func<T> action, bool forceSchedule = false);
+    }
+}

--- a/src/AlternateLife.RageMP.Net/Plugin.cs
+++ b/src/AlternateLife.RageMP.Net/Plugin.cs
@@ -36,6 +36,7 @@ namespace AlternateLife.RageMP.Net
         internal Config Config { get; }
         internal World World { get; }
         internal Commands Commands { get; }
+        internal Utility Utility { get; }
 
         internal Logger Logger { get; }
         internal ArgumentConverter ArgumentConverter { get; }
@@ -55,6 +56,7 @@ namespace AlternateLife.RageMP.Net
             Logger = new Logger(this);
             EventScripting = new EventScripting(this);
             Commands = new Commands(this);
+            Utility = new Utility(this);
 
             PlayerPool = CreateNativeManager<PlayerPool>(Rage.Multiplayer.Multiplayer_GetPlayerPool);
             VehiclePool = CreateNativeManager<VehiclePool>(Rage.Multiplayer.Multiplayer_GetVehiclePool);

--- a/src/AlternateLife.RageMP.Net/Scripting/MP.cs
+++ b/src/AlternateLife.RageMP.Net/Scripting/MP.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using AlternateLife.RageMP.Net.Helpers;
 using AlternateLife.RageMP.Net.Interfaces;
 
 namespace AlternateLife.RageMP.Net.Scripting
@@ -25,6 +23,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         public static IConfig Config => _plugin.Config;
         public static IWorld World => _plugin.World;
         public static ICommands Commands => _plugin.Commands;
+        public static IUtility Utility => _plugin.Utility;
 
         public static ILogger Logger => _plugin.Logger;
 
@@ -42,27 +41,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// <returns>Integer that represents given string data</returns>
         public static uint Joaat(string data)
         {
-            if (string.IsNullOrEmpty(data))
-            {
-                return 0;
-            }
-
-            var characters = Encoding.UTF8.GetBytes(data.ToLower());
-
-            uint hash = 0;
-
-            foreach (var t in characters)
-            {
-                hash += t;
-                hash += hash << 10;
-                hash ^= hash >> 6;
-            }
-
-            hash += hash << 3;
-            hash ^= hash >> 11;
-            hash += hash << 15;
-
-            return hash;
+            return _plugin.Utility.Joaat(data);
         }
 
         /// <summary>
@@ -74,16 +53,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// <returns>Collection of converted values</returns>
         public static IList<uint> Joaat(IList<string> input)
         {
-            Contract.NotNull(input, nameof(input));
-
-            var result = new uint[input.Count];
-
-            for (var i = 0; i < input.Count; i++)
-            {
-                result[i] = Joaat(input[i]);
-            }
-
-            return result;
+            return _plugin.Utility.Joaat(input);
         }
 
         /// <summary>
@@ -95,7 +65,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
         public static Task Schedule(Action action, bool forceSchedule = false)
         {
-            return _plugin.Schedule(action, forceSchedule);
+            return _plugin.Utility.Schedule(action, forceSchedule);
         }
 
         /// <summary>
@@ -107,7 +77,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
         public static Task<T> Schedule<T>(Func<T> action, bool forceSchedule = false)
         {
-            return _plugin.Schedule(action, forceSchedule);
+            return _plugin.Utility.Schedule(action, forceSchedule);
         }
 
     }

--- a/src/AlternateLife.RageMP.Net/Scripting/MP.cs
+++ b/src/AlternateLife.RageMP.Net/Scripting/MP.cs
@@ -39,6 +39,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// </summary>
         /// <param name="data">text to convert</param>
         /// <returns>Integer that represents given string data</returns>
+        [Obsolete("Use MP.Utility.Jooat(string data) instead")]
         public static uint Joaat(string data)
         {
             return _plugin.Utility.Joaat(data);
@@ -51,6 +52,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// </summary>
         /// <param name="input">texts to convert</param>
         /// <returns>Collection of converted values</returns>
+        [Obsolete("Use MP.Utility.Jooat(IList<string> input) instead")]
         public static IList<uint> Joaat(IList<string> input)
         {
             return _plugin.Utility.Joaat(input);
@@ -63,6 +65,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// </summary>
         /// <param name="action"><paramref name="action"/> to schedule</param>
         /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
+        [Obsolete("Use MP.Utility.Schedule(Action action, bool forceSchedule = false) instead")]
         public static Task Schedule(Action action, bool forceSchedule = false)
         {
             return _plugin.Utility.Schedule(action, forceSchedule);
@@ -75,6 +78,7 @@ namespace AlternateLife.RageMP.Net.Scripting
         /// </summary>
         /// <param name="action"><paramref name="action"/> to schedule</param>
         /// <param name="forceSchedule">If true, main thread check will be ignored and action will be scheduled</param>
+        [Obsolete("Use MP.Utility.Schedule<T>(Func<T> action, bool forceSchedule = false) instead")]
         public static Task<T> Schedule<T>(Func<T> action, bool forceSchedule = false)
         {
             return _plugin.Utility.Schedule(action, forceSchedule);

--- a/src/AlternateLife.RageMP.Net/Scripting/ScriptingClasses/Utility.cs
+++ b/src/AlternateLife.RageMP.Net/Scripting/ScriptingClasses/Utility.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AlternateLife.RageMP.Net.Helpers;
+using AlternateLife.RageMP.Net.Interfaces;
+
+namespace AlternateLife.RageMP.Net.Scripting.ScriptingClasses
+{
+    internal class Utility : IUtility
+    {
+        private readonly Plugin _plugin;
+
+        internal Utility(Plugin plugin)
+        {
+            _plugin = plugin;
+        }
+
+        public uint Joaat(string data)
+        {
+            if (string.IsNullOrEmpty(data))
+            {
+                return 0;
+            }
+
+            var characters = Encoding.UTF8.GetBytes(data.ToLower());
+
+            uint hash = 0;
+
+            foreach (var t in characters)
+            {
+                hash += t;
+                hash += hash << 10;
+                hash ^= hash >> 6;
+            }
+
+            hash += hash << 3;
+            hash ^= hash >> 11;
+            hash += hash << 15;
+
+            return hash;
+        }
+
+        public IList<uint> Joaat(IList<string> input)
+        {
+            Contract.NotNull(input, nameof(input));
+
+            var result = new uint[input.Count];
+
+            for (var i = 0; i < input.Count; i++)
+            {
+                result[i] = Joaat(input[i]);
+            }
+
+            return result;
+        }
+
+        public Task Schedule(Action action, bool forceSchedule = false)
+        {
+            return _plugin.Schedule(action, forceSchedule);
+        }
+
+        public Task<T> Schedule<T>(Func<T> action, bool forceSchedule = false)
+        {
+            return _plugin.Schedule(action, forceSchedule);
+        }
+    }
+}


### PR DESCRIPTION
Moves all APIs of the static `MP` class to a dedicated interface `IUtility` in preparation for new JSON serializer.

Old:
```cs
MP.Joaat("testobject");
```

New: 
```cs
MP.Utility.Joaat("testobject");
```